### PR TITLE
Add WASM to mimeTypes.ts

### DIFF
--- a/src/mimeTypes.ts
+++ b/src/mimeTypes.ts
@@ -176,4 +176,5 @@ export const mimeTypes: Record<string, string> = {
     '.xml': 'application/xml',
     '.xul': 'application/vnd.mozilla.xul+xml',
     '.zip': 'application/zip',
+    '.wasm': 'application/wasm',
 };


### PR DESCRIPTION
Should fix this error:`WebAssembly.instantiateStreaming` failed because your server does not serve Wasm with `application/wasm` MIME type. Falling back to `WebAssembly.instantiate` which is slower. Original error:
 TypeError: Failed to execute 'compile' on 'WebAssembly': Incorrect response MIME type. Expected 'application/wasm'.

Tested with a local patch